### PR TITLE
Establish Kipnerter platform foundation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,13 @@
+KIPNERTER_ENV=development
+KIPNERTER_PUBLIC_HOST=kipnerter.com
+KIPNERTER_ADMIN_HOST=scottjoyner.dev
+KIPNERTER_API_HOST=api.kipnerter.com
+NEXT_PUBLIC_API_URL=http://localhost:8000
+CORS_ORIGINS=http://localhost:3000,https://kipnerter.com,https://scottjoyner.dev
+# Private services should resolve over Tailscale; never commit credentials here.
+ASSISTX_BASE_URL=
+SOPHIA_BASE_URL=
+LMSTUDIO_BASE_URL=
+NEO4J_URI=
+NEO4J_USERNAME=
+NEO4J_PASSWORD=

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - run: docker compose config --quiet
+      - run: docker compose -f docker-compose.yml -f compose.dev.yml config --quiet
       - run: docker compose build
+
+  terraform:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: infra/digitalocean/terraform
+    steps:
+      - uses: actions/checkout@v4
+      - uses: hashicorp/setup-terraform@v3
+      - run: terraform fmt -check -recursive
+      - run: terraform init -backend=false
+      - run: terraform validate
 
   secrets:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,8 @@ jobs:
     defaults:
       run:
         working-directory: apps/api
+    env:
+      PYTHONPATH: .
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,54 @@
+name: ci
+
+on:
+  push:
+    branches: [master, main, "agent/**"]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  api:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: apps/api
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: apps/api/requirements-dev.txt
+      - run: pip install -r requirements-dev.txt
+      - run: pytest -q
+
+  web:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: apps/web
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+      - run: npm install
+      - run: npm run build
+
+  containers:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: docker compose build
+
+  secrets:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,69 @@
+name: deploy
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: Deployment environment
+        required: true
+        type: choice
+        options:
+          - staging
+          - production
+        default: staging
+
+permissions:
+  contents: read
+
+concurrency:
+  group: kipnerter-${{ inputs.environment }}
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.environment }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Join tailnet
+        uses: tailscale/github-action@v4
+        with:
+          oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
+          oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
+          tags: tag:kipnerter-ci
+
+      - name: Configure SSH
+        env:
+          DEPLOY_HOST: ${{ secrets.KIPNERTER_DEPLOY_HOST }}
+          DEPLOY_USER: ${{ secrets.KIPNERTER_DEPLOY_USER }}
+          SSH_PRIVATE_KEY: ${{ secrets.KIPNERTER_DEPLOY_SSH_KEY }}
+        run: |
+          set -euo pipefail
+          install -m 0700 -d ~/.ssh
+          printf '%s\n' "$SSH_PRIVATE_KEY" > ~/.ssh/id_ed25519
+          chmod 0600 ~/.ssh/id_ed25519
+          ssh-keyscan -H "$DEPLOY_HOST" >> ~/.ssh/known_hosts
+          printf 'Host kipnerter-target\n  HostName %s\n  User %s\n  IdentityFile ~/.ssh/id_ed25519\n' "$DEPLOY_HOST" "$DEPLOY_USER" >> ~/.ssh/config
+
+      - name: Deploy immutable git revision
+        env:
+          DEPLOY_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          ssh kipnerter-target "cd /opt/kipnerter && git fetch origin && git checkout --detach '$DEPLOY_SHA' && docker compose --profile edge build && docker compose --profile edge up -d --remove-orphans"
+
+      - name: Verify public health
+        run: |
+          set -euo pipefail
+          for attempt in {1..20}; do
+            if curl --fail --silent --show-error https://api.kipnerter.com/health; then
+              exit 0
+            fi
+            sleep 5
+          done
+          exit 1
+
+      - name: Show deployment state on failure
+        if: failure()
+        run: ssh kipnerter-target "cd /opt/kipnerter && docker compose ps && docker compose logs --tail=100 api web caddy" || true

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,18 +33,15 @@ jobs:
           oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
           tags: tag:kipnerter-ci
 
-      - name: Configure SSH
+      - name: Configure Tailscale SSH target
         env:
           DEPLOY_HOST: ${{ secrets.KIPNERTER_DEPLOY_HOST }}
           DEPLOY_USER: ${{ secrets.KIPNERTER_DEPLOY_USER }}
-          SSH_PRIVATE_KEY: ${{ secrets.KIPNERTER_DEPLOY_SSH_KEY }}
         run: |
           set -euo pipefail
           install -m 0700 -d ~/.ssh
-          printf '%s\n' "$SSH_PRIVATE_KEY" > ~/.ssh/id_ed25519
-          chmod 0600 ~/.ssh/id_ed25519
           ssh-keyscan -H "$DEPLOY_HOST" >> ~/.ssh/known_hosts
-          printf 'Host kipnerter-target\n  HostName %s\n  User %s\n  IdentityFile ~/.ssh/id_ed25519\n' "$DEPLOY_HOST" "$DEPLOY_USER" >> ~/.ssh/config
+          printf 'Host kipnerter-target\n  HostName %s\n  User %s\n' "$DEPLOY_HOST" "$DEPLOY_USER" >> ~/.ssh/config
 
       - name: Deploy immutable git revision
         env:

--- a/.github/workflows/dns-preflight.yml
+++ b/.github/workflows/dns-preflight.yml
@@ -1,0 +1,53 @@
+name: dns-preflight
+
+on:
+  workflow_dispatch:
+    inputs:
+      expected_ip:
+        description: Expected Kipnerter production IPv4
+        required: true
+        default: "143.198.19.141"
+
+permissions:
+  contents: read
+
+jobs:
+  dns:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check public DNS
+        env:
+          EXPECTED_IP: ${{ inputs.expected_ip }}
+        run: |
+          set -euo pipefail
+
+          check_record() {
+            host="$1"
+            expected="$2"
+            echo "== $host =="
+            system_value="$(dig +short A "$host" | tail -n1 || true)"
+            google_value="$(dig @8.8.8.8 +short A "$host" | tail -n1 || true)"
+            cloudflare_value="$(dig @1.1.1.1 +short A "$host" | tail -n1 || true)"
+            echo "system:     ${system_value:-<none>}"
+            echo "google:     ${google_value:-<none>}"
+            echo "cloudflare: ${cloudflare_value:-<none>}"
+            if [[ -n "$expected" ]]; then
+              [[ "$google_value" == "$expected" ]] || return 1
+              [[ "$cloudflare_value" == "$expected" ]] || return 1
+            fi
+          }
+
+          check_record preview.kipnerter.com "$EXPECTED_IP"
+          check_record api.kipnerter.com "$EXPECTED_IP"
+
+      - name: Show apex and authoritative nameservers
+        if: always()
+        run: |
+          echo '== kipnerter.com A =='
+          dig +short A kipnerter.com
+          echo '== kipnerter.com NS =='
+          dig +short NS kipnerter.com
+          echo '== TTL view =='
+          dig kipnerter.com A +noall +answer
+          dig preview.kipnerter.com A +noall +answer
+          dig api.kipnerter.com A +noall +answer

--- a/.github/workflows/infrastructure.yml
+++ b/.github/workflows/infrastructure.yml
@@ -1,0 +1,58 @@
+name: infrastructure
+
+on:
+  workflow_dispatch:
+    inputs:
+      action:
+        description: Infrastructure operation
+        required: true
+        type: choice
+        options:
+          - inventory
+          - terraform-plan
+        default: inventory
+
+permissions:
+  contents: read
+
+jobs:
+  inspect:
+    runs-on: ubuntu-latest
+    environment: production
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install doctl
+        if: inputs.action == 'inventory'
+        uses: digitalocean/action-doctl@v2
+        with:
+          token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
+
+      - name: Inventory DigitalOcean
+        if: inputs.action == 'inventory'
+        env:
+          DIGITALOCEAN_ACCESS_TOKEN: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
+        run: bash infra/digitalocean/inventory.sh
+
+      - name: Setup Terraform
+        if: inputs.action == 'terraform-plan'
+        uses: hashicorp/setup-terraform@v3
+
+      - name: Terraform plan
+        if: inputs.action == 'terraform-plan'
+        working-directory: infra/digitalocean/terraform
+        env:
+          TF_VAR_digitalocean_token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
+        run: |
+          set -euo pipefail
+          terraform init -backend=false
+          terraform validate
+          terraform plan -input=false -lock=false -out=tfplan
+
+      - name: Render Terraform plan
+        if: inputs.action == 'terraform-plan'
+        working-directory: infra/digitalocean/terraform
+        run: terraform show -no-color tfplan
+
+# Deliberately no terraform apply here. Persistent remote state and import of
+# existing resources must be established before CI is permitted to mutate DO.

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,14 @@
+.DS_Store
+.env
+.env.*
+!.env.example
+node_modules/
+.next/
+dist/
+coverage/
+__pycache__/
+*.py[cod]
+.pytest_cache/
+.venv/
+venv/
+*.log

--- a/README.md
+++ b/README.md
@@ -1,1 +1,64 @@
-# kipnerter
+# Kipnerter
+
+Kipnerter is the public web and API control plane for the Kipnerter ecosystem: the companion web experience for `kipnerter-ios`, the public interface for Sophia and AssistX, and the gateway for research, ingestion, embeddings, MCP tools, and private model infrastructure.
+
+## Domains
+
+- `https://kipnerter.com` — public/product experience (DNS cutover pending)
+- `https://scottjoyner.dev` — authenticated admin/operator experience
+- `https://api.kipnerter.com` — versioned API gateway (DNS cutover pending)
+
+## Architecture
+
+The DigitalOcean edge hosts the internet-facing web/API workloads. Private AI services and data systems remain behind Tailscale and are accessed through explicit service adapters instead of being exposed directly to the internet.
+
+```text
+browser / iOS
+      |
+      v
+DigitalOcean edge (Caddy)
+      |
+      +--> web
+      +--> api
+             |
+             +--> AssistX / Sophia
+             +--> research / ingest / MCP
+             +--> private Tailscale services
+                    +--> LM Studio / Ollama
+                    +--> Neo4j
+                    +--> Redis / workers
+```
+
+## Repository layout
+
+```text
+apps/
+  web/        public + admin web shell
+  api/        FastAPI gateway
+infra/
+  caddy/      public edge routing
+  digitalocean/ deployment notes/topology
+  docker/     container support
+packages/     shared API/schema packages (next phase)
+docs/         architecture, deployment, security, ADRs
+kipnerter/    legacy Java application retained during migration
+```
+
+## Local development
+
+```bash
+cp .env.example .env
+docker compose up --build
+```
+
+Then open:
+
+- Web: `http://localhost:3000`
+- API health: `http://localhost:8000/health`
+- API docs: `http://localhost:8000/docs`
+
+## Current foundation scope
+
+This branch establishes the platform boundary and production topology without committing cloud credentials or changing DNS. Authentication, shared chat/conversation APIs, iOS client integration, AssistX/Sophia adapters, MCP registry, and research/embedding pipelines build on this foundation.
+
+See `docs/architecture/platform.md` and `docs/deployment/digitalocean.md`.

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:3.12-slim
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY app ./app
+EXPOSE 8000
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/apps/api/app/__init__.py
+++ b/apps/api/app/__init__.py
@@ -1,0 +1,1 @@
+"""Kipnerter API package."""

--- a/apps/api/app/main.py
+++ b/apps/api/app/main.py
@@ -3,9 +3,11 @@ from datetime import datetime, timezone
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
+from .registry import models, services
+
 app = FastAPI(
     title="Kipnerter API",
-    version="0.1.0",
+    version="0.2.0",
     description="Public API gateway for Kipnerter web, iOS, AssistX, Sophia, research, ingestion, and MCP services.",
 )
 
@@ -44,5 +46,15 @@ def api_root() -> dict:
             "ingest",
             "embeddings",
             "mcp",
+            "services",
+            "models",
         ],
     }
+
+@app.get("/api/v1/services", tags=["platform"])
+def list_services() -> dict:
+    return {"services": [service.public_dict() for service in services()]}
+
+@app.get("/api/v1/models", tags=["platform"])
+def list_models() -> dict:
+    return {"models": models()}

--- a/apps/api/app/main.py
+++ b/apps/api/app/main.py
@@ -1,0 +1,48 @@
+import os
+from datetime import datetime, timezone
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+
+app = FastAPI(
+    title="Kipnerter API",
+    version="0.1.0",
+    description="Public API gateway for Kipnerter web, iOS, AssistX, Sophia, research, ingestion, and MCP services.",
+)
+
+origins = [o.strip() for o in os.getenv("CORS_ORIGINS", "http://localhost:3000").split(",") if o.strip()]
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=origins,
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+@app.get("/health", tags=["system"])
+def health() -> dict:
+    return {
+        "status": "ok",
+        "service": "kipnerter-api",
+        "environment": os.getenv("KIPNERTER_ENV", "development"),
+        "time": datetime.now(timezone.utc).isoformat(),
+    }
+
+@app.get("/ready", tags=["system"])
+def ready() -> dict:
+    return {"status": "ready"}
+
+@app.get("/api/v1", tags=["system"])
+def api_root() -> dict:
+    return {
+        "name": "Kipnerter API",
+        "version": "v1",
+        "capabilities": [
+            "chat",
+            "agents",
+            "sophia",
+            "research",
+            "ingest",
+            "embeddings",
+            "mcp",
+        ],
+    }

--- a/apps/api/app/registry.py
+++ b/apps/api/app/registry.py
@@ -1,0 +1,46 @@
+import os
+from dataclasses import asdict, dataclass
+from typing import Optional
+
+
+@dataclass(frozen=True)
+class Service:
+    id: str
+    kind: str
+    base_url: str
+    network: str = "tailscale"
+    health_path: str = "/health"
+
+    def public_dict(self) -> dict:
+        data = asdict(self)
+        # The API exposes topology metadata but never credentials.
+        return data
+
+
+def _service(service_id: str, kind: str, env_name: str, health_path: str = "/health") -> Optional[Service]:
+    value = os.getenv(env_name, "").strip().rstrip("/")
+    if not value:
+        return None
+    return Service(service_id, kind, value, "tailscale", health_path)
+
+
+def services() -> list[Service]:
+    candidates = [
+        _service("assistx", "agent-gateway", "ASSISTX_BASE_URL"),
+        _service("sophia", "voice", "SOPHIA_BASE_URL"),
+        _service("lmstudio", "openai-compatible", "LMSTUDIO_BASE_URL", "/v1/models"),
+    ]
+    return [service for service in candidates if service is not None]
+
+
+def models() -> list[dict]:
+    # Provider/model discovery will replace this bootstrap view once remote
+    # OpenAI-compatible endpoints are connected.
+    return [
+        {
+            "provider": service.id,
+            "discovery_url": f"{service.base_url}/v1/models",
+        }
+        for service in services()
+        if service.kind == "openai-compatible"
+    ]

--- a/apps/api/requirements-dev.txt
+++ b/apps/api/requirements-dev.txt
@@ -1,0 +1,3 @@
+-r requirements.txt
+pytest==8.4.1
+httpx==0.28.1

--- a/apps/api/requirements.txt
+++ b/apps/api/requirements.txt
@@ -1,0 +1,3 @@
+fastapi==0.116.1
+uvicorn[standard]==0.35.0
+pydantic-settings==2.10.1

--- a/apps/api/tests/test_system.py
+++ b/apps/api/tests/test_system.py
@@ -20,3 +20,19 @@ def test_api_root_capabilities():
     assert body['version'] == 'v1'
     assert 'agents' in body['capabilities']
     assert 'mcp' in body['capabilities']
+    assert 'services' in body['capabilities']
+    assert 'models' in body['capabilities']
+
+def test_empty_service_registry_without_configuration(monkeypatch):
+    for name in ('ASSISTX_BASE_URL', 'SOPHIA_BASE_URL', 'LMSTUDIO_BASE_URL'):
+        monkeypatch.delenv(name, raising=False)
+    response = client.get('/api/v1/services')
+    assert response.status_code == 200
+    assert response.json() == {'services': []}
+
+def test_lmstudio_discovery(monkeypatch):
+    monkeypatch.setenv('LMSTUDIO_BASE_URL', 'http://models.tailnet:1234')
+    response = client.get('/api/v1/models')
+    assert response.status_code == 200
+    assert response.json()['models'][0]['provider'] == 'lmstudio'
+    assert response.json()['models'][0]['discovery_url'].endswith('/v1/models')

--- a/apps/api/tests/test_system.py
+++ b/apps/api/tests/test_system.py
@@ -1,0 +1,22 @@
+from fastapi.testclient import TestClient
+from app.main import app
+
+client = TestClient(app)
+
+def test_health():
+    response = client.get('/health')
+    assert response.status_code == 200
+    assert response.json()['status'] == 'ok'
+
+def test_ready():
+    response = client.get('/ready')
+    assert response.status_code == 200
+    assert response.json() == {'status': 'ready'}
+
+def test_api_root_capabilities():
+    response = client.get('/api/v1')
+    assert response.status_code == 200
+    body = response.json()
+    assert body['version'] == 'v1'
+    assert 'agents' in body['capabilities']
+    assert 'mcp' in body['capabilities']

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -1,0 +1,17 @@
+FROM node:22-alpine AS deps
+WORKDIR /app
+COPY package.json ./
+RUN npm install
+
+FROM node:22-alpine AS build
+WORKDIR /app
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+RUN npm run build
+
+FROM node:22-alpine AS runner
+WORKDIR /app
+ENV NODE_ENV=production
+COPY --from=build /app .
+EXPOSE 3000
+CMD ["npm", "start"]

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -1,0 +1,17 @@
+* { box-sizing: border-box; }
+html, body { margin: 0; min-height: 100%; background: #090b10; color: #f4f6fb; font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
+a { color: inherit; text-decoration: none; }
+body { background: radial-gradient(circle at 80% 0%, #17233e 0, #090b10 42%); }
+.shell { width: min(1120px, calc(100% - 40px)); margin: 0 auto; padding: 96px 0; }
+.hero { max-width: 820px; padding: 56px 0 72px; }
+.eyebrow { letter-spacing: .22em; font-size: .78rem; opacity: .62; }
+h1 { font-size: clamp(3rem, 8vw, 6.8rem); line-height: .94; letter-spacing: -.055em; margin: 18px 0 28px; }
+.lead { font-size: clamp(1.05rem, 2vw, 1.35rem); line-height: 1.65; color: #b9c2d4; max-width: 760px; }
+.actions { display: flex; gap: 12px; margin-top: 36px; }
+.actions a { padding: 13px 18px; border-radius: 999px; background: #f4f6fb; color: #090b10; font-weight: 650; }
+.actions .secondary { background: transparent; color: #f4f6fb; border: 1px solid #3d4658; }
+.grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 14px; }
+.card { min-height: 180px; padding: 24px; border: 1px solid #252b38; border-radius: 20px; background: rgba(20,24,33,.72); backdrop-filter: blur(14px); }
+.card h2 { margin: 0 0 12px; font-size: 1.1rem; }
+.card p { margin: 0; color: #9ca8bd; line-height: 1.55; }
+@media (max-width: 760px) { .shell { padding-top: 44px; } .hero { padding-top: 32px; } .grid { grid-template-columns: 1fr; } }

--- a/apps/web/app/layout.js
+++ b/apps/web/app/layout.js
@@ -1,0 +1,14 @@
+import "./globals.css";
+
+export const metadata = {
+  title: "Kipnerter",
+  description: "Public web and AI platform gateway for Kipnerter.",
+};
+
+export default function RootLayout({ children }) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/apps/web/app/page.js
+++ b/apps/web/app/page.js
@@ -1,0 +1,35 @@
+const services = [
+  ["Chat", "A shared conversation surface for web and Kipnerter iOS."],
+  ["Sophia", "Voice and assistant experiences backed by the Kipnerter API."],
+  ["AssistX", "Run agents, tools, and workflows from any authenticated device."],
+  ["Research", "Launch research and ingestion jobs with traceable provenance."],
+  ["MCP", "Discover and invoke approved MCP servers and tools."],
+  ["Admin", "Operate models, services, queues, agents, and infrastructure."],
+];
+
+export default function Home() {
+  return (
+    <main className="shell">
+      <section className="hero">
+        <p className="eyebrow">KIPNERTER</p>
+        <h1>Your AI systems, available anywhere.</h1>
+        <p className="lead">
+          The public web companion to Kipnerter iOS and the gateway to Sophia,
+          AssistX, research, ingestion, MCP tooling, and private model infrastructure.
+        </p>
+        <div className="actions">
+          <a href="/chat">Open chat</a>
+          <a className="secondary" href="https://scottjoyner.dev">Admin</a>
+        </div>
+      </section>
+      <section className="grid">
+        {services.map(([name, description]) => (
+          <article className="card" key={name}>
+            <h2>{name}</h2>
+            <p>{description}</p>
+          </article>
+        ))}
+      </section>
+    </main>
+  );
+}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@kipnerter/web",
+  "private": true,
+  "version": "0.1.0",
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "next": "15.4.6",
+    "react": "19.1.1",
+    "react-dom": "19.1.1"
+  }
+}

--- a/compose.dev.yml
+++ b/compose.dev.yml
@@ -1,0 +1,13 @@
+services:
+  web:
+    environment:
+      NEXT_PUBLIC_API_URL: http://localhost:8000
+    ports:
+      - "3000:3000"
+
+  api:
+    environment:
+      KIPNERTER_ENV: development
+      CORS_ORIGINS: http://localhost:3000
+    ports:
+      - "8000:8000"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,50 @@
+services:
+  web:
+    build:
+      context: ./apps/web
+    environment:
+      NEXT_PUBLIC_API_URL: ${NEXT_PUBLIC_API_URL:-http://localhost:8000}
+    ports:
+      - "3000:3000"
+    depends_on:
+      api:
+        condition: service_healthy
+    restart: unless-stopped
+
+  api:
+    build:
+      context: ./apps/api
+    environment:
+      KIPNERTER_ENV: ${KIPNERTER_ENV:-development}
+      CORS_ORIGINS: ${CORS_ORIGINS:-http://localhost:3000}
+      ASSISTX_BASE_URL: ${ASSISTX_BASE_URL:-}
+      SOPHIA_BASE_URL: ${SOPHIA_BASE_URL:-}
+      LMSTUDIO_BASE_URL: ${LMSTUDIO_BASE_URL:-}
+    ports:
+      - "8000:8000"
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8000/health')"]
+      interval: 10s
+      timeout: 3s
+      retries: 5
+    restart: unless-stopped
+
+  caddy:
+    image: caddy:2
+    profiles: ["edge"]
+    ports:
+      - "80:80"
+      - "443:443"
+      - "443:443/udp"
+    volumes:
+      - ./infra/caddy/Caddyfile:/etc/caddy/Caddyfile:ro
+      - caddy_data:/data
+      - caddy_config:/config
+    depends_on:
+      - web
+      - api
+    restart: unless-stopped
+
+volumes:
+  caddy_data:
+  caddy_config:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,31 +3,33 @@ services:
     build:
       context: ./apps/web
     environment:
-      NEXT_PUBLIC_API_URL: ${NEXT_PUBLIC_API_URL:-http://localhost:8000}
-    ports:
-      - "3000:3000"
+      NEXT_PUBLIC_API_URL: ${NEXT_PUBLIC_API_URL:-https://api.kipnerter.com}
+    expose:
+      - "3000"
     depends_on:
       api:
         condition: service_healthy
     restart: unless-stopped
+    networks: [frontend]
 
   api:
     build:
       context: ./apps/api
     environment:
-      KIPNERTER_ENV: ${KIPNERTER_ENV:-development}
-      CORS_ORIGINS: ${CORS_ORIGINS:-http://localhost:3000}
+      KIPNERTER_ENV: ${KIPNERTER_ENV:-production}
+      CORS_ORIGINS: ${CORS_ORIGINS:-https://kipnerter.com,https://www.kipnerter.com,https://scottjoyner.dev}
       ASSISTX_BASE_URL: ${ASSISTX_BASE_URL:-}
       SOPHIA_BASE_URL: ${SOPHIA_BASE_URL:-}
       LMSTUDIO_BASE_URL: ${LMSTUDIO_BASE_URL:-}
-    ports:
-      - "8000:8000"
+    expose:
+      - "8000"
     healthcheck:
       test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8000/health')"]
       interval: 10s
       timeout: 3s
       retries: 5
     restart: unless-stopped
+    networks: [frontend, backend]
 
   caddy:
     image: caddy:2
@@ -44,6 +46,12 @@ services:
       - web
       - api
     restart: unless-stopped
+    networks: [frontend]
+
+networks:
+  frontend:
+  backend:
+    internal: true
 
 volumes:
   caddy_data:

--- a/docs/architecture/platform.md
+++ b/docs/architecture/platform.md
@@ -1,0 +1,49 @@
+# Kipnerter Platform Architecture
+
+## Purpose
+
+Kipnerter is the public web and API control plane for Scott's AI ecosystem. It provides a shared interface for browser and iOS clients while keeping private model, graph, voice, and agent infrastructure off the public internet.
+
+## Trust boundaries
+
+1. Public edge: Caddy, web, and API on DigitalOcean.
+2. Authenticated application plane: sessions, users, conversations, agent runs, research jobs, admin UI.
+3. Private service plane: AssistX, Sophia, LM Studio/Ollama, Neo4j, Redis/workers, MCP servers, ingestion and embedding workers.
+4. Tailscale is the preferred transport between DigitalOcean and private services.
+
+## Domain roles
+
+- `kipnerter.com`: public/product UI.
+- `api.kipnerter.com`: versioned API for web and iOS.
+- `scottjoyner.dev`: authenticated operator/admin UI.
+- `admin.scottjoyner.dev`: optional explicit admin alias.
+
+Authorization must be enforced by the API. Hostname-based UI routing is not an authorization mechanism.
+
+## API direction
+
+The browser and Kipnerter iOS should share one contract under `/api/v1` with streaming under `/ws` or SSE where appropriate.
+
+Initial capability namespaces:
+
+- auth
+- conversations/chat/models
+- agents/runs/events
+- sophia
+- research
+- documents/ingest
+- search/embeddings/graph
+- services/health
+- mcp
+
+## Research and provenance
+
+Ingested knowledge must retain source provenance. Derived records should preserve source URL/repository/file/commit, ingestion run, chunk identity, embedding model/version, entities, and citations so agent answers can resolve back to evidence.
+
+## MCP
+
+MCP endpoints are registered as capabilities, not hard-coded directly into agents. Registry metadata should include transport, endpoint, available tools/resources, required scopes, network scope, and health.
+
+## Migration
+
+The existing `kipnerter/` Java application remains in place during the foundation PR. It is legacy code and should not receive new platform features. Once the new stack is proven and useful assets are inventoried, it can move to `legacy/java-kipnerter/` in a dedicated migration change.

--- a/docs/deployment/digitalocean.md
+++ b/docs/deployment/digitalocean.md
@@ -1,0 +1,77 @@
+# DigitalOcean Deployment
+
+## Known account topology (2026-08-14)
+
+### Project: current scottjoyner.dev resources
+
+- Domain: `scottjoyner.dev`
+- Droplet `ubuntu-s-2vcpu-4gb-nyc3-01`
+  - NYC3
+  - 4 GB RAM / 80 GB disk
+  - IPv4 `143.198.19.141`
+- Droplet `caddy`
+  - NYC1
+  - 1 GB RAM / 25 GB disk
+  - IPv4 `143.244.166.142`
+
+### Project: Personal Portfolio / kipnerter.com
+
+Current observed DNS records supplied from the DigitalOcean control panel:
+
+- `A kipnerter.com -> 143.244.166.142`
+- `A app.kipnerter.com -> 165.227.81.99`
+- `TXT _acme-challenge.kipnerter.com -> <existing ACME token>`
+
+The apex therefore currently lands on the existing `caddy` droplet. Treat this as a live dependency until the replacement service is verified. Do not overwrite the apex or ACME record during foundation work.
+
+## Recommended production target
+
+Prefer the 4 GB NYC3 droplet (`143.198.19.141`) for the first complete Kipnerter application stack, subject to an inventory of what is already running there. The 1 GB `caddy` droplet can remain the existing edge during migration or be retired after traffic is cut over safely.
+
+Target services:
+
+- Caddy public edge
+- Kipnerter web
+- Kipnerter API
+- lightweight queue/worker services where appropriate
+- Tailscale client for private service connectivity
+
+GPU inference, Neo4j datasets, Sophia/AssistX heavy workloads, and private MCP services should remain behind Tailscale unless there is a deliberate reason to host them in DigitalOcean.
+
+## Pre-cutover checklist
+
+1. Inventory running processes, containers, Caddy configuration, disk usage, firewall state, and Tailscale state on both droplets.
+2. Snapshot/back up both droplets before destructive changes.
+3. Confirm registrar nameserver delegation and export the current DNS zone.
+4. Preserve all existing MX records before any nameserver migration. DigitalOcean only becomes authoritative after registrar delegation; missing MX records can interrupt mail.
+5. Verify the `165.227.81.99` owner/service behind `app.kipnerter.com` before changing that record.
+6. Deploy and validate web/API using a temporary hostname before apex cutover.
+7. Add/verify Cloud Firewall rules: 80/443 public; SSH restricted to known management sources/Tailscale where feasible; application ports not exposed publicly.
+8. Verify TLS and health probes.
+9. Lower DNS TTL ahead of a planned cutover if faster rollback is desired.
+10. Switch DNS only after smoke tests pass; retain a rollback path to `143.244.166.142`.
+
+## DNS target (after validation)
+
+A likely final topology is:
+
+```text
+kipnerter.com           -> production edge
+www.kipnerter.com       -> production edge
+api.kipnerter.com       -> production edge
+scottjoyner.dev         -> production edge/admin UI
+admin.scottjoyner.dev   -> production edge/admin UI
+```
+
+Actual A/AAAA values should not be changed until the target host has been inventoried and validated.
+
+## Security baseline
+
+- SSH key authentication only.
+- Non-root sudo deployment user.
+- Disable password root login.
+- DigitalOcean Cloud Firewall in addition to host firewall controls.
+- Enable monitoring; strongly consider backups/snapshots before migration.
+- Secrets supplied at deploy time; never committed to GitHub.
+- Tailscale for private east/west service access.
+- No direct public exposure of Neo4j, Redis, LM Studio, Ollama, AssistX internal endpoints, or Sophia internal endpoints.

--- a/docs/deployment/dns-cutover.md
+++ b/docs/deployment/dns-cutover.md
@@ -1,0 +1,85 @@
+# DNS cutover: fastest safe path
+
+## Goal
+
+Retain the existing 4 GB NYC3 Droplet (`414171540`, `143.198.19.141`) as the Kipnerter production host, rebuild its disk in place, validate through `preview.kipnerter.com`, then move the public apex with a short DNS TTL.
+
+A DigitalOcean Droplet rebuild preserves the Droplet's public IP while replacing the disk image. Do not destroy this Droplet if preserving `143.198.19.141` matters.
+
+## Phase 0 — start cache expiry now
+
+In the DigitalOcean DNS zone for `kipnerter.com`:
+
+1. Leave the current apex value unchanged (`kipnerter.com -> 143.244.166.142`).
+2. Change the apex TTL from `3600` to `300`.
+3. Create `preview.kipnerter.com` as an A record to `143.198.19.141`, TTL `300`.
+4. Create `api.kipnerter.com` as an A record to `143.198.19.141`, TTL `300` if it does not already exist.
+5. Do not modify `app.kipnerter.com` yet.
+6. Do not remove `_acme-challenge.kipnerter.com`.
+7. Preserve every MX/TXT record in the zone.
+
+Changing the apex TTL does not immediately invalidate resolver caches that already observed the old TTL. Allow up to the previous 3600-second TTL for those caches to age out before relying on a five-minute cutover window.
+
+## Phase 1 — snapshot and rebuild the retained host
+
+Before rebuild:
+
+- run the read-only cloud inventory workflow
+- inventory host services and Docker volumes
+- create a DigitalOcean snapshot of Droplet `414171540`
+- record the snapshot ID
+- verify console/SSH access path
+
+Then rebuild Droplet `414171540` using a current Ubuntu LTS image. Rebuild, do not destroy/recreate, because destroying releases the current public IPv4 address.
+
+After rebuild:
+
+- bootstrap the `kipnerter` deployment user
+- install Docker and Tailscale
+- attach the host as `tag:kipnerter-prod` / `tag:kipnerter-edge`
+- enable Tailscale SSH
+- clone this repository to `/opt/kipnerter`
+- deploy the edge profile
+- apply the DigitalOcean Cloud Firewall after confirming Tailscale connectivity
+
+## Phase 2 — validate before apex cutover
+
+Validate all of the following through `143.198.19.141` / the preview hostname:
+
+- `https://preview.kipnerter.com`
+- `https://api.kipnerter.com/health`
+- `https://api.kipnerter.com/ready`
+- web -> API connectivity
+- Tailscale SSH from an administrative node
+- GitHub Actions -> Tailscale -> production host deployment connectivity
+- certificate issuance and renewal path
+
+Do not move the apex until preview and API are healthy.
+
+## Phase 3 — apex cutover
+
+Change only the apex A record:
+
+`kipnerter.com: 143.244.166.142 -> 143.198.19.141`
+
+Keep TTL at 300 during the migration window.
+
+Then validate using multiple resolvers and networks. Leave the old Caddy Droplet online until the previous 3600-second cache window plus an operational safety margin has elapsed.
+
+## Phase 4 — stabilization
+
+When traffic is consistently reaching `143.198.19.141`:
+
+- verify `www.kipnerter.com`
+- verify `api.kipnerter.com`
+- verify `preview.kipnerter.com`
+- confirm no requests depend on `app.kipnerter.com`
+- increase stable DNS TTL later (for example 1800-3600)
+- snapshot the old Caddy Droplet
+- retire old Droplet `302306571` only after rollback is no longer required
+
+## Rollback
+
+If the new host is unhealthy after the apex move, restore the apex A record to `143.244.166.142`. With caches already aged down to the 300-second TTL, most compliant resolvers should refresh on approximately that cadence, though resolver behavior is not guaranteed.
+
+Never destroy the old Caddy host until rollback is no longer needed.

--- a/docs/deployment/rebuild-runbook.md
+++ b/docs/deployment/rebuild-runbook.md
@@ -1,0 +1,119 @@
+# Kipnerter DigitalOcean rebuild runbook
+
+This runbook treats the legacy DigitalOcean workloads as disposable after a final inventory/snapshot checkpoint. Do not delete DNS zones, snapshots, volumes, or droplets until the current service inventory has been captured.
+
+## Known legacy topology
+
+| Resource | Current value | Intended disposition |
+| --- | --- | --- |
+| `caddy` droplet | `302306571` / `143.244.166.142` / NYC1 / 1 GB | retire after cutover |
+| `ubuntu-s-2vcpu-4gb-nyc3-01` | `414171540` / `143.198.19.141` / NYC3 / 4 GB | preferred first production host or rebuild target |
+| `kipnerter.com` apex | `143.244.166.142` | preserve until new edge passes validation |
+| `app.kipnerter.com` | `165.227.81.99` | inventory owner/workload before modifying |
+| `_acme-challenge.kipnerter.com` | existing TXT record | preserve during migration |
+
+## Required secrets
+
+Create GitHub Environments named `staging` and `production`. Require manual approval on `production` before deployment. Store these environment secrets rather than committing credentials:
+
+- `DIGITALOCEAN_ACCESS_TOKEN`
+- `TS_OAUTH_CLIENT_ID`
+- `TS_OAUTH_SECRET`
+- `KIPNERTER_DEPLOY_HOST` (MagicDNS hostname or Tailscale IP)
+- `KIPNERTER_DEPLOY_USER` (`kipnerter` after bootstrap)
+
+The Tailscale OAuth client used by GitHub CI must be allowed to create auth keys for `tag:kipnerter-ci`. Host provisioning should use a credential allowed to assign `tag:kipnerter-prod` and `tag:kipnerter-edge`.
+
+## Phase 0: inspect only
+
+Run the `infrastructure` workflow with `inventory`. Capture droplets, DNS, firewalls, volumes and reserved IPs. On each legacy host also capture:
+
+```bash
+docker ps -a
+docker images
+docker volume ls
+docker network ls
+sudo ss -lntup
+sudo systemctl --type=service --state=running
+sudo crontab -l || true
+sudo du -sh /var/lib/docker/* 2>/dev/null || true
+sudo find /etc/caddy /opt /srv /var/www -maxdepth 2 -type f 2>/dev/null | sort
+```
+
+Archive only configs/data that are recognizable and still required.
+
+## Phase 1: establish persistent Terraform state
+
+CI deliberately cannot `terraform apply` yet. Before mutation, configure a persistent encrypted remote backend and import any existing DigitalOcean resources that will be retained. Do not keep state as a GitHub artifact or commit it to the repository.
+
+For the current 4 GB droplet, the eventual import shape is:
+
+```bash
+terraform import digitalocean_droplet.prod 414171540
+```
+
+Only perform the import after `main.tf` is adjusted to match the retained host closely enough that the next plan does not replace it unexpectedly.
+
+For an existing DNS zone that Terraform will manage later:
+
+```bash
+terraform import digitalocean_domain.kipnerter kipnerter.com
+```
+
+Import every DNS record that must survive before setting `manage_dns=true`.
+
+## Phase 2: bootstrap the production host
+
+Run Ansible against the selected/rebuilt host:
+
+```bash
+ansible-playbook -i '<host>,' -u root infra/ansible/playbooks/bootstrap.yml
+ansible-playbook -i '<host>,' -u root infra/ansible/playbooks/tailscale.yml \
+  -e "tailscale_auth_key=$TS_AUTHKEY"
+```
+
+After Tailscale SSH is validated, remove public SSH ingress from the DigitalOcean Cloud Firewall unless there is a documented break-glass CIDR.
+
+Clone this repository to `/opt/kipnerter`, configure production secrets outside git, and validate:
+
+```bash
+docker compose --profile edge build
+docker compose --profile edge up -d
+curl -fsS https://api.kipnerter.com/health
+```
+
+Do not change the apex DNS record until a temporary hostname or direct-host test proves Caddy, web and API health.
+
+## Phase 3: DNS cutover
+
+1. Reduce TTL ahead of the cutover when practical.
+2. Confirm MX/TXT/verification records are preserved.
+3. Point `api.kipnerter.com` and a temporary validation hostname to the new edge first.
+4. Validate TLS, web, API, WebSocket/SSE paths and Tailscale-only upstream services.
+5. Change the `kipnerter.com` apex only after validation.
+6. Leave the old edge online through the rollback window.
+
+## Phase 4: retire legacy hosts
+
+After the new deployment and DNS have remained healthy, use `infra/digitalocean/destroy-old-host.sh`. It requires a droplet-specific confirmation string and takes a final snapshot before deletion.
+
+Example:
+
+```bash
+DROPLET_ID=302306571 \
+CONFIRM_DESTROY=DESTROY-302306571 \
+DIGITALOCEAN_ACCESS_TOKEN=... \
+bash infra/digitalocean/destroy-old-host.sh
+```
+
+Never point the script at the active production host. Terraform's production resource also has `prevent_destroy = true` as an independent safety rail.
+
+## Rollback
+
+Deployments use immutable Git SHAs. To roll back on the host:
+
+```bash
+ROLLBACK_SHA=<known-good-sha> bash scripts/rollback.sh
+```
+
+During DNS migration, the fastest infrastructure rollback is to restore the previous A record while the legacy edge is still alive.

--- a/docs/deployment/rebuild-runbook.md
+++ b/docs/deployment/rebuild-runbook.md
@@ -1,16 +1,20 @@
 # Kipnerter DigitalOcean rebuild runbook
 
-This runbook treats the legacy DigitalOcean workloads as disposable after a final inventory/snapshot checkpoint. Do not delete DNS zones, snapshots, volumes, or droplets until the current service inventory has been captured.
+This runbook treats the legacy DigitalOcean workloads as disposable after a final inventory/snapshot checkpoint. The accelerated path retains the existing 4 GB NYC3 Droplet and rebuilds it in place so its public IP stays `143.198.19.141`.
 
 ## Known legacy topology
 
 | Resource | Current value | Intended disposition |
 | --- | --- | --- |
 | `caddy` droplet | `302306571` / `143.244.166.142` / NYC1 / 1 GB | retire after cutover |
-| `ubuntu-s-2vcpu-4gb-nyc3-01` | `414171540` / `143.198.19.141` / NYC3 / 4 GB | preferred first production host or rebuild target |
-| `kipnerter.com` apex | `143.244.166.142` | preserve until new edge passes validation |
+| `ubuntu-s-2vcpu-4gb-nyc3-01` | `414171540` / `143.198.19.141` / NYC3 / 4 GB | rebuild in place as production |
+| `kipnerter.com` apex | `143.244.166.142`, TTL 3600 | reduce TTL first; preserve until validation |
 | `app.kipnerter.com` | `165.227.81.99` | inventory owner/workload before modifying |
 | `_acme-challenge.kipnerter.com` | existing TXT record | preserve during migration |
+
+DigitalOcean rebuilds preserve the Droplet's public IP while wiping/replacing its disk. Do **not** destroy Droplet `414171540` if we intend to retain `143.198.19.141`.
+
+See `docs/deployment/dns-cutover.md` for the accelerated DNS procedure.
 
 ## Required secrets
 
@@ -24,35 +28,94 @@ Create GitHub Environments named `staging` and `production`. Require manual appr
 
 The Tailscale OAuth client used by GitHub CI must be allowed to create auth keys for `tag:kipnerter-ci`. Host provisioning should use a credential allowed to assign `tag:kipnerter-prod` and `tag:kipnerter-edge`.
 
-## Phase 0: inspect only
+## Phase 0: start DNS cache expiry and inspect
 
-Run the `infrastructure` workflow with `inventory`. Capture droplets, DNS, firewalls, volumes and reserved IPs. On each legacy host also capture:
+Before changing any IP target, edit the existing `kipnerter.com` apex record in DigitalOcean and reduce TTL from `3600` to `300` while leaving its value at `143.244.166.142`.
+
+Create:
+
+- `preview.kipnerter.com` A `143.198.19.141`, TTL `300`
+- `api.kipnerter.com` A `143.198.19.141`, TTL `300` if absent
+
+Do not change `app.kipnerter.com` or delete the ACME/MX/TXT records.
+
+Then run the `infrastructure` workflow with `inventory`. Capture droplets, DNS, firewalls, volumes, images/snapshots, SSH keys and reserved IPs. On the retained 4 GB host also capture:
 
 ```bash
-docker ps -a
-docker images
-docker volume ls
-docker network ls
+docker ps -a || true
+docker images || true
+docker volume ls || true
+docker network ls || true
 sudo ss -lntup
 sudo systemctl --type=service --state=running
 sudo crontab -l || true
 sudo du -sh /var/lib/docker/* 2>/dev/null || true
-sudo find /etc/caddy /opt /srv /var/www -maxdepth 2 -type f 2>/dev/null | sort
+sudo find /etc/caddy /opt /srv /var/www -maxdepth 3 -type f 2>/dev/null | sort
 ```
 
 Archive only configs/data that are recognizable and still required.
 
-## Phase 1: establish persistent Terraform state
+## Phase 1: final snapshot and rebuild
 
-CI deliberately cannot `terraform apply` yet. Before mutation, configure a persistent encrypted remote backend and import any existing DigitalOcean resources that will be retained. Do not keep state as a GitHub artifact or commit it to the repository.
+Create a final named snapshot of Droplet `414171540` and record its snapshot ID. Then use DigitalOcean's **Rebuild / Restore base image** action to rebuild that same Droplet with a current Ubuntu LTS image.
 
-For the current 4 GB droplet, the eventual import shape is:
+Rebuild is intentionally different from destroy/recreate: the rebuild wipes the disk but preserves `143.198.19.141`.
+
+After rebuild, its SSH host fingerprint will change. Bootstrap access using a registered DigitalOcean SSH key.
+
+## Phase 2: bootstrap the production host
+
+Run Ansible against the rebuilt host:
+
+```bash
+ansible-playbook -i '143.198.19.141,' -u root infra/ansible/playbooks/bootstrap.yml
+ansible-playbook -i '143.198.19.141,' -u root infra/ansible/playbooks/tailscale.yml \
+  -e "tailscale_auth_key=$TS_AUTHKEY"
+```
+
+Expected host state:
+
+- `kipnerter` deployment user
+- Docker Engine + Compose plugin
+- Tailscale on the host
+- `tag:kipnerter-prod` and `tag:kipnerter-edge`
+- Tailscale SSH enabled
+- repository cloned to `/opt/kipnerter`
+- only 80/443 publicly exposed after Cloud Firewall activation
+
+After Tailscale SSH is validated, remove public SSH ingress unless there is a documented break-glass CIDR.
+
+## Phase 3: preview deployment
+
+Deploy the edge stack:
+
+```bash
+cd /opt/kipnerter
+docker compose --profile edge build
+docker compose --profile edge up -d --remove-orphans
+```
+
+Validate:
+
+- `https://preview.kipnerter.com`
+- `https://api.kipnerter.com/health`
+- `https://api.kipnerter.com/ready`
+- Tailscale SSH
+- GitHub Actions deployment connectivity
+
+The repository Caddy config already accepts `preview.kipnerter.com`.
+
+## Phase 4: establish persistent Terraform state and reconcile
+
+CI deliberately cannot `terraform apply` yet. Before mutation, configure a persistent encrypted backend and import retained resources rather than recreating them.
+
+For the retained 4 GB Droplet, the eventual import shape is:
 
 ```bash
 terraform import digitalocean_droplet.prod 414171540
 ```
 
-Only perform the import after `main.tf` is adjusted to match the retained host closely enough that the next plan does not replace it unexpectedly.
+Only perform the import after `main.tf` is adjusted from the real account inventory so the subsequent plan does not replace the Droplet unexpectedly.
 
 For an existing DNS zone that Terraform will manage later:
 
@@ -60,42 +123,21 @@ For an existing DNS zone that Terraform will manage later:
 terraform import digitalocean_domain.kipnerter kipnerter.com
 ```
 
-Import every DNS record that must survive before setting `manage_dns=true`.
+Import every retained DNS record before setting `manage_dns=true`.
 
-## Phase 2: bootstrap the production host
+## Phase 5: apex cutover
 
-Run Ansible against the selected/rebuilt host:
+Only after preview/API health is green and the previous 3600-second TTL has had time to age out, change:
 
-```bash
-ansible-playbook -i '<host>,' -u root infra/ansible/playbooks/bootstrap.yml
-ansible-playbook -i '<host>,' -u root infra/ansible/playbooks/tailscale.yml \
-  -e "tailscale_auth_key=$TS_AUTHKEY"
-```
+`kipnerter.com: 143.244.166.142 -> 143.198.19.141`
 
-After Tailscale SSH is validated, remove public SSH ingress from the DigitalOcean Cloud Firewall unless there is a documented break-glass CIDR.
+Keep TTL at `300` through the migration window. Use the `dns-preflight` workflow to compare Google and Cloudflare recursive resolver answers and display observed TTLs.
 
-Clone this repository to `/opt/kipnerter`, configure production secrets outside git, and validate:
+Leave the old Caddy host online throughout the rollback window.
 
-```bash
-docker compose --profile edge build
-docker compose --profile edge up -d
-curl -fsS https://api.kipnerter.com/health
-```
+## Phase 6: retire legacy edge
 
-Do not change the apex DNS record until a temporary hostname or direct-host test proves Caddy, web and API health.
-
-## Phase 3: DNS cutover
-
-1. Reduce TTL ahead of the cutover when practical.
-2. Confirm MX/TXT/verification records are preserved.
-3. Point `api.kipnerter.com` and a temporary validation hostname to the new edge first.
-4. Validate TLS, web, API, WebSocket/SSE paths and Tailscale-only upstream services.
-5. Change the `kipnerter.com` apex only after validation.
-6. Leave the old edge online through the rollback window.
-
-## Phase 4: retire legacy hosts
-
-After the new deployment and DNS have remained healthy, use `infra/digitalocean/destroy-old-host.sh`. It requires a droplet-specific confirmation string and takes a final snapshot before deletion.
+After the new deployment and DNS have remained healthy, use `infra/digitalocean/destroy-old-host.sh` against only the old Caddy Droplet. It requires a droplet-specific confirmation string and takes a final snapshot before deletion.
 
 Example:
 
@@ -106,14 +148,16 @@ DIGITALOCEAN_ACCESS_TOKEN=... \
 bash infra/digitalocean/destroy-old-host.sh
 ```
 
-Never point the script at the active production host. Terraform's production resource also has `prevent_destroy = true` as an independent safety rail.
+Never point the script at the retained production host.
 
 ## Rollback
 
-Deployments use immutable Git SHAs. To roll back on the host:
+Before the old Caddy host is retired, the fastest infrastructure rollback is DNS-first:
+
+`kipnerter.com -> 143.244.166.142`
+
+Application deployments use immutable Git SHAs and can also roll back on the new host:
 
 ```bash
 ROLLBACK_SHA=<known-good-sha> bash scripts/rollback.sh
 ```
-
-During DNS migration, the fastest infrastructure rollback is to restore the previous A record while the legacy edge is still alive.

--- a/docs/security/baseline.md
+++ b/docs/security/baseline.md
@@ -1,0 +1,53 @@
+# Security Baseline
+
+## Principles
+
+- Public exposure terminates at the DigitalOcean edge.
+- Internal AI/data services are private by default.
+- Authentication and authorization are enforced by the API, not only by UI routing or hostnames.
+- Secrets never enter source control.
+- Every agent/tool invocation should eventually be auditable.
+
+## Network
+
+Only Caddy should require public 80/443. API and web container ports are published for local development but should be bound privately or filtered on production hosts. Neo4j, Redis, LM Studio, Ollama, AssistX internals, Sophia internals, and MCP servers should not be directly internet-addressable.
+
+Use Tailscale for DigitalOcean-to-private-service connectivity where practical.
+
+## Identity direction
+
+Planned scopes include:
+
+- `chat:use`
+- `models:read`
+- `agents:run`
+- `research:create`
+- `documents:upload`
+- `graph:read`
+- `graph:write`
+- `mcp:invoke`
+- `services:admin`
+- `infrastructure:admin`
+
+Roles and scopes should be explicit; admin hostnames must not bypass authorization.
+
+## Repository hygiene
+
+- `.env` files are ignored.
+- `.env.example` contains names only, no credentials.
+- CI performs secret scanning.
+- Historical repositories such as askHR must be secret-scanned before code/config is copied into Kipnerter.
+
+## Production hardening
+
+Before DNS cutover:
+
+- key-only SSH
+- non-root deployment user
+- disable password root login
+- DigitalOcean Cloud Firewall
+- host firewall policy
+- monitoring
+- snapshots/backups
+- rate limits on public API endpoints
+- structured audit logs for privileged operations

--- a/infra/ansible/playbooks/bootstrap.yml
+++ b/infra/ansible/playbooks/bootstrap.yml
@@ -1,0 +1,80 @@
+---
+- name: Bootstrap Kipnerter production host
+  hosts: kipnerter
+  become: true
+  vars:
+    kipnerter_user: kipnerter
+    kipnerter_root: /opt/kipnerter
+  tasks:
+    - name: Install base packages
+      ansible.builtin.apt:
+        name:
+          - ca-certificates
+          - curl
+          - git
+          - jq
+          - ufw
+          - unattended-upgrades
+        state: present
+        update_cache: true
+
+    - name: Create application user
+      ansible.builtin.user:
+        name: "{{ kipnerter_user }}"
+        groups: sudo
+        append: true
+        shell: /bin/bash
+        create_home: true
+
+    - name: Create application root
+      ansible.builtin.file:
+        path: "{{ kipnerter_root }}"
+        state: directory
+        owner: "{{ kipnerter_user }}"
+        group: "{{ kipnerter_user }}"
+        mode: "0755"
+
+    - name: Install Docker repository key
+      ansible.builtin.shell: |
+        set -euo pipefail
+        install -m 0755 -d /etc/apt/keyrings
+        curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
+        chmod a+r /etc/apt/keyrings/docker.asc
+      args:
+        executable: /bin/bash
+        creates: /etc/apt/keyrings/docker.asc
+
+    - name: Add Docker apt repository
+      ansible.builtin.apt_repository:
+        repo: "deb [arch=amd64 signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu {{ ansible_distribution_release }} stable"
+        filename: docker
+        state: present
+
+    - name: Install Docker engine and compose plugin
+      ansible.builtin.apt:
+        name:
+          - docker-ce
+          - docker-ce-cli
+          - containerd.io
+          - docker-buildx-plugin
+          - docker-compose-plugin
+        state: present
+        update_cache: true
+
+    - name: Add application user to docker group
+      ansible.builtin.user:
+        name: "{{ kipnerter_user }}"
+        groups: docker
+        append: true
+
+    - name: Enable Docker
+      ansible.builtin.systemd:
+        name: docker
+        enabled: true
+        state: started
+
+    - name: Enable unattended security upgrades
+      ansible.builtin.systemd:
+        name: unattended-upgrades
+        enabled: true
+        state: started

--- a/infra/ansible/playbooks/tailscale.yml
+++ b/infra/ansible/playbooks/tailscale.yml
@@ -1,0 +1,47 @@
+---
+- name: Join Kipnerter hosts to Tailscale
+  hosts: kipnerter
+  become: true
+  vars:
+    tailscale_hostname: kipnerter-prod-01
+    tailscale_tags: tag:kipnerter-prod,tag:kipnerter-edge
+  tasks:
+    - name: Require a Tailscale credential
+      ansible.builtin.assert:
+        that:
+          - tailscale_auth_key is defined
+          - tailscale_auth_key | length > 0
+        fail_msg: "Pass tailscale_auth_key from a secret store; never commit it."
+
+    - name: Install Tailscale
+      ansible.builtin.shell: curl -fsSL https://tailscale.com/install.sh | sh
+      args:
+        creates: /usr/bin/tailscale
+
+    - name: Enable tailscaled
+      ansible.builtin.systemd:
+        name: tailscaled
+        enabled: true
+        state: started
+
+    - name: Register host and enable Tailscale SSH
+      ansible.builtin.command:
+        argv:
+          - tailscale
+          - up
+          - "--auth-key={{ tailscale_auth_key }}"
+          - "--hostname={{ tailscale_hostname }}"
+          - "--advertise-tags={{ tailscale_tags }}"
+          - --ssh
+          - --accept-dns=true
+      no_log: true
+      changed_when: true
+
+    - name: Show tailnet addresses
+      ansible.builtin.command: tailscale ip
+      register: tailscale_ip
+      changed_when: false
+
+    - name: Report Tailscale address
+      ansible.builtin.debug:
+        var: tailscale_ip.stdout_lines

--- a/infra/caddy/Caddyfile
+++ b/infra/caddy/Caddyfile
@@ -1,0 +1,18 @@
+{
+    email admin@kipnerter.com
+}
+
+kipnerter.com, www.kipnerter.com {
+    encode zstd gzip
+    reverse_proxy web:3000
+}
+
+api.kipnerter.com {
+    encode zstd gzip
+    reverse_proxy api:8000
+}
+
+scottjoyner.dev, admin.scottjoyner.dev {
+    encode zstd gzip
+    reverse_proxy web:3000
+}

--- a/infra/caddy/Caddyfile
+++ b/infra/caddy/Caddyfile
@@ -1,7 +1,3 @@
-{
-    email admin@kipnerter.com
-}
-
 kipnerter.com, www.kipnerter.com {
     encode zstd gzip
     reverse_proxy web:3000

--- a/infra/caddy/Caddyfile
+++ b/infra/caddy/Caddyfile
@@ -1,4 +1,4 @@
-kipnerter.com, www.kipnerter.com {
+kipnerter.com, www.kipnerter.com, preview.kipnerter.com {
     encode zstd gzip
     reverse_proxy web:3000
 }

--- a/infra/digitalocean/destroy-old-host.sh
+++ b/infra/digitalocean/destroy-old-host.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${DIGITALOCEAN_ACCESS_TOKEN:?Set DIGITALOCEAN_ACCESS_TOKEN}"
+: "${DROPLET_ID:?Set DROPLET_ID}"
+: "${CONFIRM_DESTROY:?Set CONFIRM_DESTROY to DESTROY-${DROPLET_ID}}"
+
+if [[ "$CONFIRM_DESTROY" != "DESTROY-${DROPLET_ID}" ]]; then
+  echo "Refusing destruction: confirmation token must equal DESTROY-${DROPLET_ID}" >&2
+  exit 2
+fi
+
+command -v doctl >/dev/null || { echo "doctl is required" >&2; exit 1; }
+
+export DIGITALOCEAN_ACCESS_TOKEN
+
+echo "Target droplet:"
+doctl compute droplet get "$DROPLET_ID" --format ID,Name,PublicIPv4,Region,Size,Status
+
+echo "Taking final snapshot before destruction..."
+SNAPSHOT_NAME="pre-destroy-${DROPLET_ID}-$(date -u +%Y%m%dT%H%M%SZ)"
+doctl compute droplet-action snapshot "$DROPLET_ID" --snapshot-name "$SNAPSHOT_NAME" --wait
+
+echo "Snapshot complete: $SNAPSHOT_NAME"
+echo "Destroying droplet $DROPLET_ID..."
+doctl compute droplet delete "$DROPLET_ID" --force

--- a/infra/digitalocean/inventory.sh
+++ b/infra/digitalocean/inventory.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${DIGITALOCEAN_ACCESS_TOKEN:?Set DIGITALOCEAN_ACCESS_TOKEN}"
+
+export DIGITALOCEAN_ACCESS_TOKEN
+
+command -v doctl >/dev/null || { echo "doctl is required" >&2; exit 1; }
+
+printf '\n== Account ==\n'
+doctl account get
+printf '\n== Droplets ==\n'
+doctl compute droplet list --format ID,Name,PublicIPv4,PrivateIPv4,Region,Size,Status,Tags
+printf '\n== Firewalls ==\n'
+doctl compute firewall list
+printf '\n== Volumes ==\n'
+doctl compute volume list
+printf '\n== Reserved IPs ==\n'
+doctl compute reserved-ip list || true
+printf '\n== Domains ==\n'
+doctl compute domain list
+
+for domain in kipnerter.com scottjoyner.dev; do
+  printf '\n== DNS: %s ==\n' "$domain"
+  doctl compute domain records list "$domain" || true
+done
+
+printf '\nInventory complete. No resources were modified.\n'

--- a/infra/digitalocean/terraform/main.tf
+++ b/infra/digitalocean/terraform/main.tf
@@ -1,0 +1,94 @@
+locals {
+  common_tags = ["kipnerter", "production", "managed-by-terraform"]
+}
+
+resource "digitalocean_droplet" "prod" {
+  name     = "kipnerter-prod-01"
+  region   = var.region
+  size     = var.droplet_size
+  image    = var.droplet_image
+  ssh_keys = var.ssh_key_fingerprints
+  tags     = local.common_tags
+
+  monitoring = true
+  backups    = true
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "digitalocean_firewall" "prod" {
+  name        = "kipnerter-prod"
+  droplet_ids = [digitalocean_droplet.prod.id]
+
+  inbound_rule {
+    protocol         = "tcp"
+    port_range       = "80"
+    source_addresses = ["0.0.0.0/0", "::/0"]
+  }
+
+  inbound_rule {
+    protocol         = "tcp"
+    port_range       = "443"
+    source_addresses = ["0.0.0.0/0", "::/0"]
+  }
+
+  dynamic "inbound_rule" {
+    for_each = length(var.admin_source_cidrs) > 0 ? [1] : []
+    content {
+      protocol         = "tcp"
+      port_range       = "22"
+      source_addresses = var.admin_source_cidrs
+    }
+  }
+
+  outbound_rule {
+    protocol              = "tcp"
+    port_range            = "1-65535"
+    destination_addresses = ["0.0.0.0/0", "::/0"]
+  }
+
+  outbound_rule {
+    protocol              = "udp"
+    port_range            = "1-65535"
+    destination_addresses = ["0.0.0.0/0", "::/0"]
+  }
+
+  outbound_rule {
+    protocol              = "icmp"
+    destination_addresses = ["0.0.0.0/0", "::/0"]
+  }
+}
+
+resource "digitalocean_domain" "kipnerter" {
+  count = var.manage_dns ? 1 : 0
+  name  = var.domain
+}
+
+resource "digitalocean_record" "apex" {
+  count  = var.manage_dns ? 1 : 0
+  domain = digitalocean_domain.kipnerter[0].id
+  type   = "A"
+  name   = "@"
+  value  = digitalocean_droplet.prod.ipv4_address
+  ttl    = 300
+}
+
+resource "digitalocean_record" "api" {
+  count  = var.manage_dns ? 1 : 0
+  domain = digitalocean_domain.kipnerter[0].id
+  type   = "A"
+  name   = "api"
+  value  = digitalocean_droplet.prod.ipv4_address
+  ttl    = 300
+}
+
+resource "digitalocean_record" "www" {
+  count  = var.manage_dns ? 1 : 0
+  domain = digitalocean_domain.kipnerter[0].id
+  type   = "CNAME"
+  name   = "www"
+  value  = "${var.domain}."
+  ttl    = 300
+}

--- a/infra/digitalocean/terraform/main.tf
+++ b/infra/digitalocean/terraform/main.tf
@@ -75,6 +75,15 @@ resource "digitalocean_record" "apex" {
   ttl    = 300
 }
 
+resource "digitalocean_record" "preview" {
+  count  = var.manage_dns ? 1 : 0
+  domain = digitalocean_domain.kipnerter[0].id
+  type   = "A"
+  name   = "preview"
+  value  = digitalocean_droplet.prod.ipv4_address
+  ttl    = 300
+}
+
 resource "digitalocean_record" "api" {
   count  = var.manage_dns ? 1 : 0
   domain = digitalocean_domain.kipnerter[0].id

--- a/infra/digitalocean/terraform/outputs.tf
+++ b/infra/digitalocean/terraform/outputs.tf
@@ -1,0 +1,15 @@
+output "prod_droplet_id" {
+  value = digitalocean_droplet.prod.id
+}
+
+output "prod_ipv4" {
+  value = digitalocean_droplet.prod.ipv4_address
+}
+
+output "prod_firewall_id" {
+  value = digitalocean_firewall.prod.id
+}
+
+output "dns_management_enabled" {
+  value = var.manage_dns
+}

--- a/infra/digitalocean/terraform/providers.tf
+++ b/infra/digitalocean/terraform/providers.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = ">= 1.8.0"
+
+  required_providers {
+    digitalocean = {
+      source  = "digitalocean/digitalocean"
+      version = "~> 2.96"
+    }
+  }
+}
+
+provider "digitalocean" {
+  token = var.digitalocean_token
+}

--- a/infra/digitalocean/terraform/variables.tf
+++ b/infra/digitalocean/terraform/variables.tf
@@ -1,0 +1,48 @@
+variable "digitalocean_token" {
+  description = "DigitalOcean API token. Supply via TF_VAR_digitalocean_token."
+  type        = string
+  sensitive   = true
+}
+
+variable "project_name" {
+  type    = string
+  default = "kipnerter"
+}
+
+variable "region" {
+  type    = string
+  default = "nyc3"
+}
+
+variable "droplet_size" {
+  type    = string
+  default = "s-2vcpu-4gb"
+}
+
+variable "droplet_image" {
+  type    = string
+  default = "ubuntu-24-04-x64"
+}
+
+variable "ssh_key_fingerprints" {
+  description = "DigitalOcean SSH key fingerprints permitted on newly created hosts."
+  type        = list(string)
+  default     = []
+}
+
+variable "admin_source_cidrs" {
+  description = "Optional public CIDRs allowed to reach SSH. Prefer Tailscale and leave this empty after bootstrap."
+  type        = list(string)
+  default     = []
+}
+
+variable "manage_dns" {
+  description = "False during inventory/migration. Enable only after existing DNS records have been imported and reviewed."
+  type        = bool
+  default     = false
+}
+
+variable "domain" {
+  type    = string
+  default = "kipnerter.com"
+}

--- a/infra/tailscale/policy.hujson
+++ b/infra/tailscale/policy.hujson
@@ -1,0 +1,60 @@
+{
+  // Merge these sections into the existing tailnet policy after review.
+  "tagOwners": {
+    "tag:kipnerter-prod": ["autogroup:admin"],
+    "tag:kipnerter-edge": ["autogroup:admin"],
+    "tag:kipnerter-ci": ["autogroup:admin"],
+    "tag:assistx": ["autogroup:admin"],
+    "tag:sophia": ["autogroup:admin"],
+    "tag:models": ["autogroup:admin"],
+    "tag:graph": ["autogroup:admin"]
+  },
+
+  "grants": [
+    {
+      "src": ["autogroup:admin"],
+      "dst": ["tag:kipnerter-prod"],
+      "ip": ["*"]
+    },
+    {
+      "src": ["tag:kipnerter-prod"],
+      "dst": ["tag:assistx"],
+      "ip": ["tcp:8000", "tcp:9100"]
+    },
+    {
+      "src": ["tag:kipnerter-prod"],
+      "dst": ["tag:sophia"],
+      "ip": ["tcp:8765"]
+    },
+    {
+      "src": ["tag:kipnerter-prod"],
+      "dst": ["tag:models"],
+      "ip": ["tcp:1234", "tcp:11434"]
+    },
+    {
+      "src": ["tag:kipnerter-prod"],
+      "dst": ["tag:graph"],
+      "ip": ["tcp:7687", "tcp:7474"]
+    },
+    {
+      "src": ["tag:kipnerter-ci"],
+      "dst": ["tag:kipnerter-prod"],
+      "ip": ["tcp:22", "tcp:443"]
+    }
+  ],
+
+  "ssh": [
+    {
+      "action": "check",
+      "src": ["autogroup:admin"],
+      "dst": ["tag:kipnerter-prod"],
+      "users": ["autogroup:nonroot", "root"]
+    },
+    {
+      "action": "accept",
+      "src": ["tag:kipnerter-ci"],
+      "dst": ["tag:kipnerter-prod"],
+      "users": ["kipnerter"]
+    }
+  ]
+}

--- a/scripts/rollback.sh
+++ b/scripts/rollback.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${ROLLBACK_SHA:?Set ROLLBACK_SHA to a previously validated commit}"
+
+ROOT=${KIPNERTER_ROOT:-/opt/kipnerter}
+cd "$ROOT"
+
+git fetch origin --prune
+if ! git cat-file -e "${ROLLBACK_SHA}^{commit}" 2>/dev/null; then
+  echo "Unknown rollback commit: $ROLLBACK_SHA" >&2
+  exit 2
+fi
+
+CURRENT_SHA=$(git rev-parse HEAD)
+echo "Rolling back from $CURRENT_SHA to $ROLLBACK_SHA"
+git checkout --detach "$ROLLBACK_SHA"
+docker compose --profile edge build
+docker compose --profile edge up -d --remove-orphans
+
+for attempt in {1..20}; do
+  if curl --fail --silent http://127.0.0.1:8000/health >/dev/null 2>&1 || docker compose exec -T api python -c "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8000/health')"; then
+    echo "Rollback healthy at $ROLLBACK_SHA"
+    exit 0
+  fi
+  sleep 3
+done
+
+echo "Rollback deployment failed health validation." >&2
+exit 1


### PR DESCRIPTION
## What changed

Repositions the legacy `kipnerter` repository as the public web/API and infrastructure control plane for Kipnerter iOS, Sophia, AssistX, research, ingestion, embeddings, MCP tooling, and private AI infrastructure.

### Application foundation
- runnable Next.js web shell
- FastAPI gateway with health/readiness/version endpoints
- `/api/v1/services` and `/api/v1/models` bootstrap registry endpoints for AssistX, Sophia, and OpenAI-compatible model providers
- API smoke/registry tests
- Dockerfiles and hardened Compose networking: web/API are internal by default; only Caddy publishes production ports
- separate local development Compose override

### Infrastructure foundation
- DigitalOcean Terraform provider/resource scaffolding for a production droplet, Cloud Firewall, and eventual DNS ownership
- `manage_dns=false` by default so existing DNS cannot be changed accidentally
- `prevent_destroy=true` on the managed production droplet
- read-only `doctl` inventory script for droplets, firewalls, volumes, reserved IPs, and DNS
- destructive legacy-droplet helper gated by a droplet-specific confirmation token and a final snapshot
- Ansible bootstrap for Docker, a dedicated `kipnerter` user, security updates, and host setup
- Tailscale host provisioning with tagged identities and Tailscale SSH
- least-privilege Tailscale grant/SSH policy template for prod, CI, AssistX, Sophia, models, and graph services
- immutable-SHA deployment workflow over Tailscale
- deployment rollback helper
- controlled rebuild/cutover runbook

### CI/security
- FastAPI tests
- Next.js production build
- Docker Compose validation and image builds
- Terraform fmt/init/validate
- gitleaks scanning
- dedicated read-only infrastructure workflow for DigitalOcean inventory and Terraform planning

## Known DigitalOcean topology

The migration docs preserve the supplied live state:

- `caddy` droplet: `302306571` / `143.244.166.142` (NYC1 / 1 GB), currently serving the `kipnerter.com` apex
- `ubuntu-s-2vcpu-4gb-nyc3-01`: `414171540` / `143.198.19.141` (NYC3 / 4 GB), preferred first production/rebuild target
- `app.kipnerter.com -> 165.227.81.99`, ownership/workload must be inventoried before modification
- existing `_acme-challenge.kipnerter.com` TXT record must survive migration

This PR deliberately does **not** change live DNS, destroy droplets, apply Terraform, or commit cloud/Tailscale credentials.

## Safety model

DigitalOcean becomes the hardened public edge/control plane. Heavy/private services remain on the tailnet. Application containers do not run SSH; Tailscale is installed on the host and GitHub deployment runners join with `tag:kipnerter-ci` before using Tailscale SSH.

Terraform apply is intentionally disabled until persistent remote state is configured and retained DigitalOcean resources/DNS are imported and reviewed. Production deployment is also designed to run through a protected GitHub Environment.

## Validation

The branch is currently 42 commits ahead of `master` with no divergence. Terraform fmt/init/validate, API tests, and gitleaks are green on the latest CI run; web/container jobs are also exercised by CI.

## External setup still required before live cloud mutation

1. Create a scoped DigitalOcean API token and store it as the `DIGITALOCEAN_ACCESS_TOKEN` GitHub production environment secret.
2. Create a Tailscale OAuth client with writable `auth_keys` permission for the CI/provisioning tags and store `TS_OAUTH_CLIENT_ID` / `TS_OAUTH_SECRET` in GitHub.
3. Create/protect GitHub Environments `staging` and `production` and add deployment host/user secrets.
4. Choose a persistent encrypted Terraform backend before enabling `terraform apply`.
5. Run the inventory workflow and host-level legacy inventory before any deletion or DNS cutover.

After those are in place, we can inventory the cloud account from Actions, bootstrap/rebuild the selected 4 GB host, validate a temporary/API hostname, cut DNS over, and retire the old Caddy droplet with rollback coverage.