### PR TITLE
Deploy Kipnerter spatial API behind production edge

### DIFF
--- a/.env.spatial.example
+++ b/.env.spatial.example
@@ -1,0 +1,6 @@
+# Production values belong in the protected GitHub Environment and /opt/kipnerter/.env.
+# Never commit real credentials.
+KIPNERTER_SPATIAL_API_KEY=
+KIPNERTER_SPATIAL_DB_PASSWORD=
+KIPNERTER_SPATIAL_S3_ACCESS_KEY_ID=
+KIPNERTER_SPATIAL_S3_SECRET_ACCESS_KEY=

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,6 +9,11 @@ on:
         type: choice
         options: [staging, production]
         default: staging
+      spatial_api_ref:
+        description: Exact kipnerter-api commit to deploy
+        required: true
+        default: e64a78654bd771349f75d6be1438ad69c4305e6b
+        type: string
 
 permissions:
   contents: read
@@ -21,9 +26,26 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     environment: ${{ inputs.environment }}
-    timeout-minutes: 30
+    timeout-minutes: 45
     steps:
-      - uses: actions/checkout@v4
+      - name: Check out platform control plane
+        uses: actions/checkout@v4
+
+      - name: Check out immutable spatial backend
+        uses: actions/checkout@v4
+        with:
+          repository: scottjoyner/kipnerter-api
+          ref: ${{ inputs.spatial_api_ref }}
+          path: spatial-api
+          token: ${{ secrets.KIPNERTER_API_REPO_TOKEN }}
+          fetch-depth: 1
+
+      - name: Verify spatial backend revision
+        shell: bash
+        run: |
+          set -euo pipefail
+          ACTUAL="$(git -C spatial-api rev-parse HEAD)"
+          [[ "$ACTUAL" == "${{ inputs.spatial_api_ref }}" ]] || { echo "::error::Spatial checkout $ACTUAL does not match requested ${{ inputs.spatial_api_ref }}"; exit 1; }
 
       - name: Join tailnet
         uses: tailscale/github-action@v4
@@ -68,6 +90,23 @@ jobs:
           tailscale ping --timeout=10s "$TARGET"
           tailscale ssh "$USER@$TARGET" 'hostname; docker --version; docker compose version'
 
+      - name: Validate required spatial secrets
+        if: inputs.environment == 'production'
+        env:
+          API_KEY: ${{ secrets.KIPNERTER_SPATIAL_API_KEY }}
+          DB_PASSWORD: ${{ secrets.KIPNERTER_SPATIAL_DB_PASSWORD }}
+          S3_ACCESS: ${{ secrets.KIPNERTER_SPATIAL_S3_ACCESS_KEY_ID }}
+          S3_SECRET: ${{ secrets.KIPNERTER_SPATIAL_S3_SECRET_ACCESS_KEY }}
+        run: |
+          set -euo pipefail
+          for value in API_KEY DB_PASSWORD S3_ACCESS S3_SECRET; do
+            [[ -n "${!value:-}" ]] || { echo "::error::Missing required production secret $value"; exit 1; }
+          done
+          [[ ${#API_KEY} -ge 32 ]] || { echo "::error::KIPNERTER_SPATIAL_API_KEY must be at least 32 characters"; exit 1; }
+          [[ ${#DB_PASSWORD} -ge 20 ]] || { echo "::error::KIPNERTER_SPATIAL_DB_PASSWORD must be at least 20 characters"; exit 1; }
+          [[ "$DB_PASSWORD" =~ ^[A-Za-z0-9._~-]+$ ]] || { echo "::error::KIPNERTER_SPATIAL_DB_PASSWORD must use URL-safe characters"; exit 1; }
+          [[ ${#S3_SECRET} -ge 32 ]] || { echo "::error::KIPNERTER_SPATIAL_S3_SECRET_ACCESS_KEY must be at least 32 characters"; exit 1; }
+
       - name: Upload immutable revision
         env:
           TARGET: ${{ steps.target.outputs.host }}
@@ -77,9 +116,13 @@ jobs:
           SOPHIA_BASE_URL: ${{ secrets.SOPHIA_BASE_URL }}
           LMSTUDIO_BASE_URL: ${{ secrets.LMSTUDIO_BASE_URL }}
           GATEWAY_TOKEN_OVERRIDE: ${{ secrets.KIPNERTER_GATEWAY_TOKEN }}
+          SPATIAL_API_KEY: ${{ secrets.KIPNERTER_SPATIAL_API_KEY }}
+          SPATIAL_DB_PASSWORD: ${{ secrets.KIPNERTER_SPATIAL_DB_PASSWORD }}
+          SPATIAL_S3_ACCESS_KEY_ID: ${{ secrets.KIPNERTER_SPATIAL_S3_ACCESS_KEY_ID }}
+          SPATIAL_S3_SECRET_ACCESS_KEY: ${{ secrets.KIPNERTER_SPATIAL_S3_SECRET_ACCESS_KEY }}
         run: |
           set -euo pipefail
-          tar --exclude=.git -czf /tmp/kipnerter.tgz .
+          tar --exclude=.git --exclude='*/.git' -czf /tmp/kipnerter.tgz .
           tailscale ssh "$USER@$TARGET" 'sudo mkdir -p /opt/kipnerter && sudo chown -R '"$USER:$USER"' /opt/kipnerter'
           cat /tmp/kipnerter.tgz | tailscale ssh "$USER@$TARGET" 'tar -xzf - -C /opt/kipnerter'
           if [ "$ENVIRONMENT" = production ]; then
@@ -107,9 +150,14 @@ jobs:
               printf 'KIPNERTER_GATEWAY_TOKEN=%s\n' "$GATEWAY_TOKEN"
               printf 'GATEWAY_MAX_BODY_BYTES=1048576\n'
               printf 'GATEWAY_UPSTREAM_TIMEOUT_SECONDS=20\n'
+              printf 'KIPNERTER_SPATIAL_API_KEY=%s\n' "$SPATIAL_API_KEY"
+              printf 'KIPNERTER_SPATIAL_DB_PASSWORD=%s\n' "$SPATIAL_DB_PASSWORD"
+              printf 'KIPNERTER_SPATIAL_S3_ACCESS_KEY_ID=%s\n' "$SPATIAL_S3_ACCESS_KEY_ID"
+              printf 'KIPNERTER_SPATIAL_S3_SECRET_ACCESS_KEY=%s\n' "$SPATIAL_S3_SECRET_ACCESS_KEY"
             } > /tmp/kipnerter.env
             chmod 600 /tmp/kipnerter.env
             cat /tmp/kipnerter.env | tailscale ssh "$USER@$TARGET" 'cat > /opt/kipnerter/.env && chmod 600 /opt/kipnerter/.env'
+            rm -f /tmp/kipnerter.env
           fi
 
       - name: Build and deploy
@@ -118,7 +166,7 @@ jobs:
           USER: ${{ steps.target.outputs.user }}
         run: |
           set -euo pipefail
-          tailscale ssh "$USER@$TARGET" 'cd /opt/kipnerter && docker compose --profile edge config >/tmp/kipnerter-compose.yml && docker compose --profile edge build --pull && docker compose --profile edge up -d --remove-orphans && docker compose ps'
+          tailscale ssh "$USER@$TARGET" 'cd /opt/kipnerter && docker compose -f docker-compose.yml -f compose.spatial.yml --profile edge config >/tmp/kipnerter-compose.yml && docker compose -f docker-compose.yml -f compose.spatial.yml --profile edge build --pull && docker compose -f docker-compose.yml -f compose.spatial.yml --profile edge up -d --remove-orphans && docker compose -f docker-compose.yml -f compose.spatial.yml ps'
 
       - name: Verify production health
         if: inputs.environment == 'production'
@@ -129,6 +177,8 @@ jobs:
           set -euo pipefail
           for attempt in {1..30}; do
             if curl -fsS https://api.kipnerter.com/health >/dev/null && \
+               curl -fsS https://api.kipnerter.com/health/live >/dev/null && \
+               curl -fsS https://api.kipnerter.com/health/ready >/dev/null && \
                curl -fsS https://api.kipnerter.com/api/v1/services >/dev/null && \
                curl -fsS https://api.kipnerter.com/api/v1/services/health >/dev/null && \
                curl -fsS https://api.kipnerter.com/api/v1/gateway/routes >/dev/null && \
@@ -144,4 +194,4 @@ jobs:
         env:
           TARGET: ${{ steps.target.outputs.host }}
           USER: ${{ steps.target.outputs.user }}
-        run: tailscale ssh "$USER@$TARGET" 'cd /opt/kipnerter && docker compose ps && docker compose logs --tail=150 api web caddy' || true
+        run: tailscale ssh "$USER@$TARGET" 'cd /opt/kipnerter && docker compose -f docker-compose.yml -f compose.spatial.yml ps && docker compose -f docker-compose.yml -f compose.spatial.yml logs --tail=150 api web caddy spatial-api spatial-worker spatial-postgres spatial-minio' || true

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .env
 .env.*
 !.env.example
+!.env.spatial.example
 node_modules/
 .next/
 dist/

--- a/compose.spatial.yml
+++ b/compose.spatial.yml
@@ -1,0 +1,81 @@
+services:
+  spatial-api:
+    build:
+      context: ./spatial-api
+    environment: &spatial-env
+      KIPNERTER_ENVIRONMENT: production
+      KIPNERTER_PERSISTENCE_MODE: database
+      KIPNERTER_DATABASE_URL: postgresql+asyncpg://kipnerter:${KIPNERTER_SPATIAL_DB_PASSWORD}@spatial-postgres:5432/kipnerter
+      KIPNERTER_S3_ENDPOINT_URL: http://spatial-minio:9000
+      KIPNERTER_S3_PUBLIC_ENDPOINT_URL: https://api.kipnerter.com
+      KIPNERTER_S3_REGION: us-east-1
+      KIPNERTER_S3_BUCKET: kipnerter-artifacts
+      KIPNERTER_S3_ACCESS_KEY_ID: ${KIPNERTER_SPATIAL_S3_ACCESS_KEY_ID}
+      KIPNERTER_S3_SECRET_ACCESS_KEY: ${KIPNERTER_SPATIAL_S3_SECRET_ACCESS_KEY}
+      KIPNERTER_AUTH_MODE: api_key
+      KIPNERTER_API_KEY: ${KIPNERTER_SPATIAL_API_KEY}
+    expose:
+      - "8000"
+    depends_on:
+      spatial-postgres:
+        condition: service_healthy
+      spatial-minio:
+        condition: service_healthy
+    restart: unless-stopped
+    networks: [frontend, spatial_backend]
+
+  spatial-worker:
+    build:
+      context: ./spatial-api
+    entrypoint: []
+    command: ["python", "-m", "kipnerter_api.worker"]
+    environment: *spatial-env
+    depends_on:
+      spatial-api:
+        condition: service_started
+      spatial-postgres:
+        condition: service_healthy
+      spatial-minio:
+        condition: service_healthy
+    restart: unless-stopped
+    networks: [spatial_backend]
+
+  spatial-postgres:
+    image: postgis/postgis:16-3.4
+    environment:
+      POSTGRES_DB: kipnerter
+      POSTGRES_USER: kipnerter
+      POSTGRES_PASSWORD: ${KIPNERTER_SPATIAL_DB_PASSWORD}
+    volumes:
+      - spatial_postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U kipnerter -d kipnerter"]
+      interval: 5s
+      timeout: 3s
+      retries: 30
+    restart: unless-stopped
+    networks: [spatial_backend]
+
+  spatial-minio:
+    image: minio/minio:latest
+    command: server /data
+    environment:
+      MINIO_ROOT_USER: ${KIPNERTER_SPATIAL_S3_ACCESS_KEY_ID}
+      MINIO_ROOT_PASSWORD: ${KIPNERTER_SPATIAL_S3_SECRET_ACCESS_KEY}
+    volumes:
+      - spatial_minio_data:/data
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
+      interval: 5s
+      timeout: 3s
+      retries: 30
+    restart: unless-stopped
+    networks: [frontend, spatial_backend]
+
+networks:
+  spatial_backend:
+    internal: true
+
+volumes:
+  spatial_postgres_data:
+  spatial_minio_data:

--- a/docs/deployment/spatial-api-checklist.md
+++ b/docs/deployment/spatial-api-checklist.md
@@ -1,0 +1,14 @@
+# Spatial API release checklist
+
+- [ ] Production GitHub Environment contains the private-repo checkout token and four spatial runtime secrets.
+- [ ] `spatial_api_ref` is an exact reviewed `kipnerter-api` commit.
+- [ ] `docker compose -f docker-compose.yml -f compose.spatial.yml --profile edge config` succeeds.
+- [ ] `api.kipnerter.com/health` continues to serve the platform gateway.
+- [ ] `api.kipnerter.com/health/live` and `/health/ready` serve the spatial API.
+- [ ] Unauthenticated `/v1/*` requests are rejected while health probes remain reachable.
+- [ ] PostGIS and MinIO have persistent named volumes.
+- [ ] MinIO ports and console are not published directly.
+- [ ] A presigned PUT URL uses `https://api.kipnerter.com/kipnerter-artifacts/...`, never a Docker hostname.
+- [ ] One physical RoomPlan export reaches `synced` on iOS and `complete` in the backend.
+- [ ] The RoomPlan worker stores a successful processing report.
+- [ ] A sanitized real-device JSON fixture is committed to `kipnerter-api` after validation.

--- a/docs/deployment/spatial-api.md
+++ b/docs/deployment/spatial-api.md
@@ -1,0 +1,58 @@
+# Spatial API production deployment
+
+`kipnerter-api` is deployed as a private-source service behind the existing Kipnerter public edge. It does not replace the existing platform gateway.
+
+## Public routing
+
+`api.kipnerter.com` remains the single public API origin:
+
+- `/api/v1/*` and other existing gateway routes -> platform `api`
+- `/v1/*`, `/health/live`, `/health/ready`, `/version` -> `spatial-api`
+- `/kipnerter-artifacts/*` -> private MinIO service for SigV4-signed object operations only
+
+MinIO ports and its console are never published directly. Presigned URLs are generated against `https://api.kipnerter.com` while the backend uses `http://spatial-minio:9000` internally.
+
+## Persistent services
+
+The production overlay adds:
+
+- `spatial-api`
+- `spatial-worker`
+- PostgreSQL 16 + PostGIS 3.4
+- MinIO object storage
+
+PostgreSQL and MinIO use named Docker volumes. The worker consumes transactional `scan.completed` events and normalizes verified RoomPlan JSON artifacts.
+
+## Required production secrets
+
+Configure these in the protected `production` GitHub Environment:
+
+- `KIPNERTER_API_REPO_TOKEN` — read-only token able to check out the private `scottjoyner/kipnerter-api` repository
+- `KIPNERTER_SPATIAL_API_KEY` — minimum 32-character bearer token used by the internal TestFlight client
+- `KIPNERTER_SPATIAL_DB_PASSWORD` — minimum 20-character PostgreSQL password; use URL-safe characters
+- `KIPNERTER_SPATIAL_S3_ACCESS_KEY_ID` — MinIO access key
+- `KIPNERTER_SPATIAL_S3_SECRET_ACCESS_KEY` — minimum 32-character MinIO secret
+
+Existing Tailscale/deployment secrets remain required by the normal Kipnerter deploy workflow.
+
+## Immutable source contract
+
+The deploy workflow accepts an exact `spatial_api_ref`. GitHub Actions checks out that exact private commit, verifies its SHA, bundles it with the public control plane, then transfers the combined immutable source tree to the production node over Tailscale. The production host therefore does not need GitHub credentials.
+
+## First device enrollment
+
+Kipnerter iOS defaults to `https://api.kipnerter.com`. A finalized RoomPlan remains local until a spatial bearer token is present. If an unsynced finalized export exists and the token is missing, the app asks for the token once and stores it in the iOS Keychain. Per-room autosaves never trigger server completion.
+
+For the first internal TestFlight validation:
+
+1. deploy the production overlay and verify `/health/live` and `/health/ready`;
+2. install/open the current internal TestFlight build;
+3. capture and save one RoomPlan;
+4. enter `KIPNERTER_SPATIAL_API_KEY` in the secure enrollment prompt;
+5. verify the manifest progresses to `synced`;
+6. verify Postgres contains the completed scan and processing report;
+7. preserve a sanitized copy of the real RoomPlan JSON as the backend regression fixture.
+
+## Rollback
+
+The spatial databases/object volumes are persistent and are not removed by `docker compose up -d --remove-orphans`. An application rollback should deploy a previously validated platform + spatial backend SHA pair. Do not use `docker compose down -v` in production.

--- a/infra/caddy/Caddyfile
+++ b/infra/caddy/Caddyfile
@@ -5,7 +5,20 @@ kipnerter.com, www.kipnerter.com, preview.kipnerter.com {
 
 api.kipnerter.com {
     encode zstd gzip
-    reverse_proxy api:8000
+
+    @spatial_api path /v1/* /health/live /health/ready /version
+    handle @spatial_api {
+        reverse_proxy spatial-api:8000
+    }
+
+    @spatial_artifacts path /kipnerter-artifacts/*
+    handle @spatial_artifacts {
+        reverse_proxy spatial-minio:9000
+    }
+
+    handle {
+        reverse_proxy api:8000
+    }
 }
 
 scottjoyner.dev, admin.scottjoyner.dev {


### PR DESCRIPTION
## Summary

Adds the production control-plane wiring required to deploy the private `kipnerter-api` alongside the existing Kipnerter web/API stack without replacing the current gateway.

### Public edge

- keeps `api.kipnerter.com` as the single public API origin
- routes `/v1/*`, `/health/live`, `/health/ready`, and `/version` to the spatial FastAPI service
- keeps existing `/api/v1/*` and gateway routes on the platform API
- routes only signed `/kipnerter-artifacts/*` object requests to private MinIO
- does not publish MinIO ports or its admin console

### Spatial production stack

- `spatial-api`
- `spatial-worker`
- PostgreSQL 16 + PostGIS 3.4 with persistent volume
- MinIO with persistent volume
- production API-key auth
- internal S3 endpoint plus public SigV4 signing origin at `https://api.kipnerter.com`

### Immutable deployment

The deploy workflow now accepts an exact `spatial_api_ref`, checks out that private commit in Actions, verifies its SHA, bundles it with the public control plane, and transfers the combined tree to the tagged production node over Tailscale. The server does not need GitHub credentials.

Required new protected production secrets:

- `KIPNERTER_API_REPO_TOKEN`
- `KIPNERTER_SPATIAL_API_KEY`
- `KIPNERTER_SPATIAL_DB_PASSWORD`
- `KIPNERTER_SPATIAL_S3_ACCESS_KEY_ID`
- `KIPNERTER_SPATIAL_S3_SECRET_ACCESS_KEY`

### Release validation

Production health now verifies both the existing gateway and the spatial live/readiness endpoints. The deployment docs include the first physical RoomPlan validation path and explicitly prohibit `docker compose down -v` in production.

This PR changes no DNS records and does not destroy or recreate the production host.