### PR TITLE
Pin latest hardened spatial backend

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,7 +12,7 @@ on:
       spatial_api_ref:
         description: Exact kipnerter-api commit to deploy
         required: true
-        default: e64a78654bd771349f75d6be1438ad69c4305e6b
+        default: 3490c05ce529b9d8775e9c99f358bb95481331f5
         type: string
 
 permissions:


### PR DESCRIPTION
Advances the default production `spatial_api_ref` from the initial public-presign implementation to `3490c05ce529b9d8775e9c99f358bb95481331f5`, which is strictly ahead and adds CI hardening, outbox/worker fixes, storage unit coverage, and RoomPlan edge-case tests while retaining the public-presign changes.